### PR TITLE
Various improvements

### DIFF
--- a/vps-audit.sh
+++ b/vps-audit.sh
@@ -41,7 +41,7 @@ echo "================================" >> "$REPORT_FILE"
 print_header "System Information"
 
 # Get system information
-OS_INFO=$(cat /etc/os-release | grep PRETTY_NAME | cut -d'"' -f2)
+OS_INFO=$(grep PRETTY_NAME /etc/os-release | cut -d'"' -f2)
 KERNEL_VERSION=$(uname -r)
 HOSTNAME=$HOSTNAME
 UPTIME=$(uptime -p)
@@ -225,7 +225,7 @@ case "$IPS_INSTALLED$IPS_ACTIVE" in
 esac
 
 # Check failed login attempts
-FAILED_LOGINS=$(grep "Failed password" /var/log/auth.log 2>/dev/null | wc -l)
+FAILED_LOGINS=$(grep -c "Failed password" /var/log/auth.log 2>/dev/null || echo 0)
 if [ "$FAILED_LOGINS" -lt 10 ]; then
     check_security "Failed Logins" "PASS" "Only $FAILED_LOGINS failed login attempts detected - this is within normal range"
 elif [ "$FAILED_LOGINS" -lt 50 ]; then
@@ -245,7 +245,7 @@ else
     check_security "System Updates" "FAIL" "$UPDATES security updates available - system is vulnerable to known exploits"
 fi
 # Check running services
-SERVICES=$(systemctl list-units --type=service --state=running | grep "loaded active running" | wc -l)
+SERVICES=$(systemctl list-units --type=service --state=running | grep -c "loaded active running")
 if [ "$SERVICES" -lt 20 ]; then
     check_security "Running Services" "PASS" "Running minimal services ($SERVICES) - good for security"
 elif [ "$SERVICES" -lt 40 ]; then
@@ -364,7 +364,7 @@ echo "================================" >> "$REPORT_FILE"
 echo "System Information Summary:" >> "$REPORT_FILE"
 echo "Hostname: $(hostname)" >> "$REPORT_FILE"
 echo "Kernel: $(uname -r)" >> "$REPORT_FILE"
-echo "OS: $(cat /etc/os-release | grep PRETTY_NAME | cut -d'"' -f2)" >> "$REPORT_FILE"
+echo "OS: $(grep PRETTY_NAME /etc/os-release | cut -d'"' -f2)" >> "$REPORT_FILE"
 echo "CPU Cores: $(nproc)" >> "$REPORT_FILE"
 echo "Total Memory: $(free -h | awk '/^Mem:/ {print $2}')" >> "$REPORT_FILE"
 echo "Total Disk Space: $(df -h / | awk 'NR==2 {print $2}')" >> "$REPORT_FILE"

--- a/vps-audit.sh
+++ b/vps-audit.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Colors for output
 GREEN='\033[0;32m'
@@ -43,7 +43,7 @@ print_header "System Information"
 # Get system information
 OS_INFO=$(cat /etc/os-release | grep PRETTY_NAME | cut -d'"' -f2)
 KERNEL_VERSION=$(uname -r)
-HOSTNAME=$(hostname)
+HOSTNAME=$HOSTNAME
 UPTIME=$(uptime -p)
 UPTIME_SINCE=$(uptime -s)
 CPU_INFO=$(lscpu | grep "Model name" | cut -d':' -f2 | xargs)

--- a/vps-audit.sh
+++ b/vps-audit.sh
@@ -225,7 +225,20 @@ case "$IPS_INSTALLED$IPS_ACTIVE" in
 esac
 
 # Check failed login attempts
-FAILED_LOGINS=$(grep -c "Failed password" /var/log/auth.log 2>/dev/null || echo 0)
+LOG_FILE="/var/log/auth.log"
+
+if [ -f "$LOG_FILE" ]; then
+    FAILED_LOGINS=$(grep -c "Failed password" "$LOG_FILE" 2>/dev/null || echo 0)
+else
+    FAILED_LOGINS=0
+    echo "Warning: Log file $LOG_FILE not found or unreadable. Assuming 0 failed login attempts."
+fi
+
+# Ensure FAILED_LOGINS is numeric and strip whitespace
+FAILED_LOGINS=$(echo "$FAILED_LOGINS" | tr -d '[:space:]')
+# Remove leading zeros (if any)
+FAILED_LOGINS=$((10#$FAILED_LOGINS)) # Use arithmetic evaluation to ensure it's numeric and format correctly.
+
 if [ "$FAILED_LOGINS" -lt 10 ]; then
     check_security "Failed Logins" "PASS" "Only $FAILED_LOGINS failed login attempts detected - this is within normal range"
 elif [ "$FAILED_LOGINS" -lt 50 ]; then


### PR DESCRIPTION
`/usr/bin/env bash` is the proper way to call bash, as it may not be located in /bin on all systems.  On BSD for example it is almost always in /usr/local/bin/bash

Using grep on a file instead of piping from cat is faster and simpler.

Using the $HOSTNAME variable is faster and doesn't require the host system to have a hostname binary installed, for example my Arch machine doesn't have one.

`grep -c` is the same as `grep | wc -l`, but faster and simpler, Though it doesn't output anything to stdout on error, so I had to add a special case when reading /var/log/auth.log, as that caused issues when ran as non-root.