### PR TITLE
Improve script speed with -n option to iptables command

### DIFF
--- a/vps-audit.sh
+++ b/vps-audit.sh
@@ -178,7 +178,7 @@ check_firewall_status() {
             check_security "Firewall Status (firewalld)" "FAIL" "Firewalld is not active - your system is exposed to network attacks"
         fi
     elif command -v iptables >/dev/null 2>&1; then
-        if iptables -L | grep -q "Chain INPUT"; then
+        if iptables -L -n | grep -q "Chain INPUT"; then
             check_security "Firewall Status (iptables)" "PASS" "iptables rules are active and protecting your system"
         else
             check_security "Firewall Status (iptables)" "FAIL" "No active iptables rules found - your system may be exposed"


### PR DESCRIPTION
# Description
The security check using the iptables command is slow because it performs DNS resolution, which is unnecessary. The command iptables -L takes around 3 minutes to complete due to these resolutions, which are not required for this check. By adding the -n option, DNS resolution is avoided, improving execution time.

# Proposed changes
Add the `-n` option to the iptables `-L` command to skip DNS resolution and speed up execution.

# Results time
* Without the `-n` option (default):
```bash
sudo ./vps-audit.sh
0.00s user 0.01s system 0% cpu **3:25.20 total**
```

* With the `-n` option:
```bash
sudo ./vps-audit.sh
0.00s user 0.01s system 0% cpu **9.146 total**
```