### PR TITLE
Add docker commands to check if Fail2ban or CrowdSec containers are running

### DIFF
--- a/vps-audit.sh
+++ b/vps-audit.sh
@@ -178,7 +178,7 @@ check_firewall_status() {
             check_security "Firewall Status (firewalld)" "FAIL" "Firewalld is not active - your system is exposed to network attacks"
         fi
     elif command -v iptables >/dev/null 2>&1; then
-        if iptables -L | grep -q "Chain INPUT"; then
+        if iptables -L -n | grep -q "Chain INPUT"; then
             check_security "Firewall Status (iptables)" "PASS" "iptables rules are active and protecting your system"
         else
             check_security "Firewall Status (iptables)" "FAIL" "No active iptables rules found - your system may be exposed"

--- a/vps-audit.sh
+++ b/vps-audit.sh
@@ -213,9 +213,21 @@ if dpkg -l | grep -q "fail2ban"; then
     systemctl is-active fail2ban >/dev/null 2>&1 && IPS_ACTIVE=1
 fi
 
+# Check docker container running fail2ban
+if docker ps -a | awk '{print $2}' | grep "fail2ban"; then
+    IPS_INSTALLED=1
+    docker ps | grep -q "fail2ban" && IPS_ACTIVE=1
+fi
+
 if dpkg -l | grep -q "crowdsec"; then
     IPS_INSTALLED=1
     systemctl is-active crowdsec >/dev/null 2>&1 && IPS_ACTIVE=1
+fi
+
+# Check docker container running crowdsec
+if docker ps -a | awk '{print $2}' | grep "crowdsec"; then
+    IPS_INSTALLED=1
+    docker ps | grep -q "crowdsec" && IPS_ACTIVE=1
 fi
 
 case "$IPS_INSTALLED$IPS_ACTIVE" in


### PR DESCRIPTION
I have added Docker container commands to check if the Fail2ban or CrowdSec containers are running. The check is performed by inspecting the 'image' column.

```shell
# Check docker container running fail2ban
if docker ps -a | awk '{print $2}' | grep "fail2ban"; then
    IPS_INSTALLED=1
    docker ps | grep -q "fail2ban" && IPS_ACTIVE=1
fi
```

```shell
# Check docker container running crowdsec
if docker ps -a | awk '{print $2}' | grep "crowdsec"; then
    IPS_INSTALLED=1
    docker ps | grep -q "crowdsec" && IPS_ACTIVE=1
fi
```