### PR TITLE
Add docker commands to check if Fail2ban or CrowdSec containers are running

### DIFF
--- a/vps-audit.sh
+++ b/vps-audit.sh
@@ -213,9 +213,21 @@ if dpkg -l | grep -q "fail2ban"; then
     systemctl is-active fail2ban >/dev/null 2>&1 && IPS_ACTIVE=1
 fi
 
+# Check docker container running fail2ban
+if docker ps -a | awk '{print $2}' | grep "fail2ban"; then
+    IPS_INSTALLED=1
+    docker ps | grep -q "fail2ban" && IPS_ACTIVE=1
+fi
+
 if dpkg -l | grep -q "crowdsec"; then
     IPS_INSTALLED=1
     systemctl is-active crowdsec >/dev/null 2>&1 && IPS_ACTIVE=1
+fi
+
+# Check docker container running crowdsec
+if docker ps -a | awk '{print $2}' | grep "crowdsec"; then
+    IPS_INSTALLED=1
+    docker ps | grep -q "crowdsec" && IPS_ACTIVE=1
 fi
 
 case "$IPS_INSTALLED$IPS_ACTIVE" in

--- a/vps-audit.sh
+++ b/vps-audit.sh
@@ -214,9 +214,15 @@ if dpkg -l | grep -q "fail2ban"; then
 fi
 
 # Check docker container running fail2ban
-if docker ps -a | awk '{print $2}' | grep "fail2ban"; then
-    IPS_INSTALLED=1
-    docker ps | grep -q "fail2ban" && IPS_ACTIVE=1
+if command -v docker >/dev/null 2>&1; then
+    if systemctl is-active --quiet docker; then
+        if docker ps -a | awk '{print $2}' | grep "fail2ban" >/dev/null 2>&1; then
+            IPS_INSTALLED=1
+            docker ps | grep -q "fail2ban" && IPS_ACTIVE=1
+        fi
+    else
+        check_security "Intrusion Prevention" "WARN" "Docker is instaleld but not running - cannot check for Fail2ban containers"
+    fi
 fi
 
 if dpkg -l | grep -q "crowdsec"; then
@@ -225,9 +231,15 @@ if dpkg -l | grep -q "crowdsec"; then
 fi
 
 # Check docker container running crowdsec
-if docker ps -a | awk '{print $2}' | grep "crowdsec"; then
-    IPS_INSTALLED=1
-    docker ps | grep -q "crowdsec" && IPS_ACTIVE=1
+if command -v docker >/dev/null 2>&1; then
+    if systemctl is-active --quiet docker; then
+        if docker ps -a | awk '{print $2}' | grep "crowdsec" >/dev/null 2>&1; then
+            IPS_INSTALLED=1
+            docker ps | grep -q "crowdsec" && IPS_ACTIVE=1
+        fi
+    else
+        check_security "Intrusion Prevention" "WARN" "Docker is instaleld but not running - cannot check for CrowdSec containers"
+    fi
 fi
 
 case "$IPS_INSTALLED$IPS_ACTIVE" in


### PR DESCRIPTION
I have added Docker container commands to check if the Fail2ban or CrowdSec containers are running. The check is performed by inspecting the 'image' column.

```shell
# Check docker container running fail2ban
if docker ps -a | awk '{print $2}' | grep "fail2ban"; then
    IPS_INSTALLED=1
    docker ps | grep -q "fail2ban" && IPS_ACTIVE=1
fi
```

```shell
# Check docker container running crowdsec
if docker ps -a | awk '{print $2}' | grep "crowdsec"; then
    IPS_INSTALLED=1
    docker ps | grep -q "crowdsec" && IPS_ACTIVE=1
fi
```