### PR TITLE
fix: MINLEN failing if over 12, added customization

### DIFF
--- a/.omc/state/sessions/ff30fbbd-56d2-4b7f-a9de-0ead519f5001/pre-tool-advisory-throttle.json
+++ b/.omc/state/sessions/ff30fbbd-56d2-4b7f-a9de-0ead519f5001/pre-tool-advisory-throttle.json
@@ -1,0 +1,18 @@
+{
+  "version": 1,
+  "entries": {
+    "445ed27a3872b681d98190bae61ccb84954e1bc4e140df5370be958dee776b3a": {
+      "last_emitted_at_ms": 1786339746846,
+      "message": "Verify changes work after editing. Test functionality before marking complete."
+    },
+    "466399dafa2d20f60587180bad0a07358eb7f2bce724df0ff682f038ad33f5ad": {
+      "last_emitted_at_ms": 1786339731913,
+      "message": "Read multiple files in parallel when possible for faster analysis."
+    },
+    "79a93d4a2f8f50b95f852280616242fee1855dc99a3c75211917f55e72e95fae": {
+      "last_emitted_at_ms": 1786339728962,
+      "message": "Use parallel execution for independent tasks. Use run_in_background for long operations (npm install, builds, tests)."
+    }
+  },
+  "updated_at": "2026-08-10T05:29:06.846Z"
+}

--- a/README.md
+++ b/README.md
@@ -9,19 +9,19 @@ A comprehensive Bash script for auditing the security and performance of your VP
 
 ### Security Checks
 
-- SSH Configuration
-  - Root login status
-  - Password authentication
-  - Non-default port usage
-- Firewall Status (UFW)
-- Fail2ban Configuration
-- Failed Login Attempts
-- System Updates Status
-- Running Services Analysis
-- Open Ports Detection
-- Sudo Logging Configuration
-- Password Policy Enforcement
-- SUID Files Detection
+- **SSH Configuration**
+  - Root login status
+  - Password authentication
+  - Non-default port usage
+- **Firewall Status** (UFW/firewalld/iptables/nftables)
+- **Intrusion Prevention** (Fail2ban/CrowdSec) Configuration
+- **Failed Login Attempts**
+- **System Updates Status**
+- **Running Services** Analysis
+- **Open Ports** Detection
+- **Sudo Logging** Configuration
+- **Password Policy** Enforcement (via `pwquality.conf`)
+- **SUID Files** Detection
 
 ### Performance Monitoring
 
@@ -30,16 +30,20 @@ A comprehensive Bash script for auditing the security and performance of your VP
 - CPU Usage
 - Active Internet Connections
 
+---
+
 ## Requirements
 
 - Ubuntu/Debian-based Linux system
-- Root access or sudo privileges
+- **Root access** or `sudo` privileges
 - Basic packages (most are pre-installed):
-  - ufw
-  - systemd
-  - netstat
-  - grep
-  - awk
+  - `ufw`
+  - `systemd`
+  - `netstat`/`ss`
+  - `grep`
+  - `awk`
+
+---
 
 ## Installation
 
@@ -57,9 +61,11 @@ curl -O https://raw.githubusercontent.com/vernu/vps-audit/main/vps-audit.sh
 chmod +x vps-audit.sh
 ```
 
+-----
+
 ## Usage
 
-Run the script with sudo privileges:
+Run the script with `sudo` privileges:
 
 ```bash
 sudo ./vps-audit.sh
@@ -92,44 +98,59 @@ The script provides two types of output:
    - System resource usage statistics
    - Timestamp of the audit
 
-## Thresholds
-
-### Resource Usage Thresholds
-
-- PASS: < 50% usage
-- WARN: 50-80% usage
-- FAIL: > 80% usage
-
-### Security Thresholds
-
-- Failed Logins:
-  - PASS: < 10 attempts
-  - WARN: 10-50 attempts
-  - FAIL: > 50 attempts
-- Running Services:
-  - PASS: < 20 services
-  - WARN: 20-40 services
-  - FAIL: > 40 services
-- Open Ports:
-  - PASS: < 10 ports
-  - WARN: 10-20 ports
-  - FAIL: > 20 ports
+-----
 
 ## Customization
 
-You can modify the thresholds by editing the following variables in the script:
+The script's behavior, file paths, and scoring limits are fully controlled by variables defined in the **`Configuration`** section at the top of the script file.
 
-- Resource usage thresholds
-- Failed login attempt thresholds
-- Service count thresholds
-- Open port thresholds
+### 1. Dynamic Thresholds for PASS/WARN/FAIL Status
+
+These variables define the numerical limits that trigger a **WARN** or **FAIL** status.
+
+| Variable | Default Value | Check | Description |
+| :--- | :--- | :--- | :--- |
+| `RESOURCE_WARN` | `50` | Resource Usage | **WARN** if Disk/Memory/CPU usage is between 50-80%. |
+| `RESOURCE_FAIL` | `80` | Resource Usage | **FAIL** if Disk/Memory/CPU usage is more than 80%. |
+| `SERVICES_WARN` | `20` | Running Services | **WARN** if between 20-40 services are running. |
+| `SERVICES_FAIL` | `40` | Running Services | **FAIL** if more than 40 services are running. |
+| `LOGINS_WARN` | `10` | Failed Logins | **WARN** if between 10-50 failed login attempts are detected. |
+| `LOGINS_FAIL` | `50` | Failed Logins | **FAIL** if more than 50 failed login attempts are detected. |
+| `OPEN_PORTS_WARN` | `10` | Open Ports | **WARN** if between 10-20 listening ports are found. |
+| `OPEN_PORTS_FAIL` | `20` | Open Ports | **FAIL** if more than 20 listening ports are found. |
+
+### 2. Report Output and Ownership
+
+These variables control where the report is saved and the file permissions.
+
+| Variable | Default Value | Description |
+| :--- | :--- | :--- |
+| `DEFAULT_REPORT_DIR` | `.` *(The current directory)* | The directory where the report file will be saved. |
+| `ENABLE_CHOWN` | `false` | If `true`, sets ownership of the report file and (if newly created) the report directory to `REPORT_CHOWN_OWNER`. |
+| `REPORT_CHOWN_OWNER` | `$(id -un):$(id -gn)` | The target `user:group` for `chown`. **Note:** When run via `sudo`, this will resolve to the `root` user by default. |
+| `REPORT_FILENAME` | `vps-audit-report-$(TIMESTAMP).txt` | The template name for the generated report file. |
+
+### 3. Security Check File Paths
+
+You can adjust the paths the script uses to check critical configuration files:
+
+| Variable | Default Value | Description |
+| :--- | :--- | :--- |
+| `OS_RELEASE_FILE` | `/etc/os-release` | Path to the Operating System release file. |
+| `REBOOT_REQUIRED_FILE` | `/var/run/reboot-required` | File indicating a system restart is needed. |
+| `SSH_CONFIG_FILE` | `/etc/ssh/sshd_config` | Main SSH daemon configuration file. |
+| `AUTH_LOG_FILE` | `/var/log/auth.log` | Log file checked for failed login attempts. |
+| `SUDOERS_FILE` | `/etc/sudoers` | File checked for sudo logging configuration. |
+| `PASSWORD_QUALITY_CONF` | `/etc/security/pwquality.conf` | Password complexity policy configuration file. |
+
+---
 
 ## Best Practices
 
 1. Run the audit regularly (e.g., weekly) to maintain security
 2. Review the generated report thoroughly
-3. Address any FAIL status immediately
-4. Investigate WARN status during maintenance
+3. Address any **FAIL** status immediately
+4. Investigate **WARN** status during maintenance
 5. Keep the script updated with your security policies
 
 ## Limitations

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ curl -O https://raw.githubusercontent.com/vernu/vps-audit/main/vps-audit.sh
 chmod +x vps-audit.sh
 ```
 
------
+---
 
 ## Usage
 
@@ -98,7 +98,7 @@ The script provides two types of output:
    - System resource usage statistics
    - Timestamp of the audit
 
------
+---
 
 ## Customization
 
@@ -118,6 +118,7 @@ These variables define the numerical limits that trigger a **WARN** or **FAIL** 
 | `LOGINS_FAIL` | `50` | Failed Logins | **FAIL** if more than 50 failed login attempts are detected. |
 | `OPEN_PORTS_WARN` | `10` | Open Ports | **WARN** if between 10-20 listening ports are found. |
 | `OPEN_PORTS_FAIL` | `20` | Open Ports | **FAIL** if more than 20 listening ports are found. |
+| `PASSWORD_MINLEN` | `12` | Password Policy | **PASS** if `minlen` in `pwquality.conf` is at least this value. |
 
 ### 2. Report Output and Ownership
 
@@ -127,7 +128,7 @@ These variables control where the report is saved and the file permissions.
 | :--- | :--- | :--- |
 | `DEFAULT_REPORT_DIR` | `.` *(The current directory)* | The directory where the report file will be saved. |
 | `ENABLE_CHOWN` | `false` | If `true`, sets ownership of the report file and (if newly created) the report directory to `REPORT_CHOWN_OWNER`. |
-| `REPORT_CHOWN_OWNER` | `$(id -un):$(id -gn)` | The target `user:group` for `chown`. **Note:** When run via `sudo`, this will resolve to the `root` user by default. |
+| `REPORT_CHOWN_OWNER` | `${SUDO_USER:-$(id -un)}:<their group>` | The target `user:group` for `chown`. Defaults to the user who invoked `sudo`, so reports are not left owned by `root`. |
 | `REPORT_FILENAME` | `vps-audit-report-$(TIMESTAMP).txt` | The template name for the generated report file. |
 
 ### 3. Security Check File Paths

--- a/vps-audit.sh
+++ b/vps-audit.sh
@@ -1,5 +1,67 @@
 #!/usr/bin/env bash
 
+# -----------------------------------------
+# Configuration
+# -----------------------------------------
+
+# Static Directory/File Variables
+OS_RELEASE_FILE="/etc/os-release"
+REBOOT_REQUIRED_FILE="/var/run/reboot-required"
+SSH_CONFIG_FILE="/etc/ssh/sshd_config"
+AUTH_LOG_FILE="/var/log/auth.log"
+SUDOERS_FILE="/etc/sudoers"
+PASSWORD_QUALITY_CONF="/etc/security/pwquality.conf"
+
+# Resource Usage Thresholds (Disk/Memory/CPU %)
+RESOURCE_WARN=50  # WARN if usage is >= 50%
+RESOURCE_FAIL=80  # FAIL if usage is >= 80%
+
+# Running Services Thresholds
+SERVICES_WARN=20  # WARN if >= 20 services are running
+SERVICES_FAIL=40  # FAIL if >= 40 services are running
+
+# Failed Logins Thresholds (Count)
+LOGINS_WARN=10    # WARN if >= 10 failed logins
+LOGINS_FAIL=50    # FAIL if >= 50 failed logins
+
+# Open Ports Thresholds (Count)
+OPEN_PORTS_WARN=10  # WARN if >= 10 open ports
+OPEN_PORTS_FAIL=20  # FAIL if >= 20 open ports
+
+# Report Output Configuration
+
+# Directory and File Naming
+DEFAULT_REPORT_DIR="."   # Where reports will be saved
+TIMESTAMP=$(date +"%Y%m%d_%H%M%S")
+REPORT_FILENAME="vps-audit-report-${TIMESTAMP}.txt"
+REPORT_FILE="${DEFAULT_REPORT_DIR}/${REPORT_FILENAME}"
+
+# Ownership
+ENABLE_CHOWN=false  # Whether to apply chown to report directory
+REPORT_CHOWN_OWNER="$(id -un):$(id -gn)"  # user:group - if running via sudo will default to root:root
+
+# Ensure report directory exists
+if [ ! -d "$DEFAULT_REPORT_DIR" ]; then
+    if mkdir -p "$DEFAULT_REPORT_DIR"; then
+        # Apply ownership only when directory was created
+        if [ "$ENABLE_CHOWN" = true ]; then
+            if ! chown -R "$REPORT_CHOWN_OWNER" "$DEFAULT_REPORT_DIR"; then
+                echo -e "${RED}[ERROR] Failed to change ownership of ${DEFAULT_REPORT_DIR}." >&2
+            fi
+        fi
+    else
+        echo -e "${RED}[ERROR] Failed to create directory ${DEFAULT_REPORT_DIR}. Using current directory." >&2
+        DEFAULT_REPORT_DIR="."
+        REPORT_FILE="./${REPORT_FILENAME}"
+        ENABLE_CHOWN=false
+    fi
+fi
+
+# -----------------------------------------
+# End Configuration
+# -----------------------------------------
+
+
 # Colors for output
 GREEN='\033[0;32m'
 RED='\033[0;31m'
@@ -8,10 +70,6 @@ GRAY='\033[0;90m'
 BLUE='\033[0;34m'
 BOLD='\033[1m'
 NC='\033[0m' # No Color
-
-# Get current timestamp for the report filename
-TIMESTAMP=$(date +"%Y%m%d_%H%M%S")
-REPORT_FILE="vps-audit-report-${TIMESTAMP}.txt"
 
 print_header() {
     local header="$1"
@@ -41,7 +99,7 @@ echo "================================" >> "$REPORT_FILE"
 print_header "System Information"
 
 # Get system information
-OS_INFO=$(grep PRETTY_NAME /etc/os-release | cut -d'"' -f2)
+OS_INFO=$(grep PRETTY_NAME "$OS_RELEASE_FILE" | cut -d'"' -f2)
 KERNEL_VERSION=$(uname -r)
 HOSTNAME=$HOSTNAME
 UPTIME=$(uptime -p)
@@ -103,20 +161,20 @@ echo "" >> "$REPORT_FILE"
 echo -e "System Uptime: $UPTIME (since $UPTIME_SINCE)"
 
 # Check if system requires restart
-if [ -f /var/run/reboot-required ]; then
+if [ -f "$REBOOT_REQUIRED_FILE" ]; then
     check_security "System Restart" "WARN" "System requires a restart to apply updates"
 else
     check_security "System Restart" "PASS" "No restart required"
 fi
 
 # Check SSH config overrides
-SSH_CONFIG_OVERRIDES=$(grep "^Include" /etc/ssh/sshd_config 2>/dev/null | awk '{print $2}')
+SSH_CONFIG_OVERRIDES=$(grep "^Include" "$SSH_CONFIG_FILE" 2>/dev/null | awk '{print $2}')
 
 # Check SSH root login (handle both main config and overrides if they exist)
 if [ -n "$SSH_CONFIG_OVERRIDES" ] && [ -d "$(dirname "$SSH_CONFIG_OVERRIDES")" ]; then
-    SSH_ROOT=$(grep "^PermitRootLogin" $SSH_CONFIG_OVERRIDES /etc/ssh/sshd_config 2>/dev/null | head -1 | awk '{print $2}')
+    SSH_ROOT=$(grep "^PermitRootLogin" $SSH_CONFIG_OVERRIDES "$SSH_CONFIG_FILE" 2>/dev/null | head -1 | awk '{print $2}')
 else
-    SSH_ROOT=$(grep "^PermitRootLogin" /etc/ssh/sshd_config 2>/dev/null | head -1 | awk '{print $2}')
+    SSH_ROOT=$(grep "^PermitRootLogin" "$SSH_CONFIG_FILE" 2>/dev/null | head -1 | awk '{print $2}')
 fi
 if [ -z "$SSH_ROOT" ]; then
     SSH_ROOT="prohibit-password"
@@ -124,14 +182,14 @@ fi
 if [ "$SSH_ROOT" = "no" ]; then
     check_security "SSH Root Login" "PASS" "Root login is properly disabled in SSH configuration"
 else
-    check_security "SSH Root Login" "FAIL" "Root login is currently allowed - this is a security risk. Disable it in /etc/ssh/sshd_config"
+    check_security "SSH Root Login" "FAIL" "Root login is currently allowed - this is a security risk. Disable it in $SSH_CONFIG_FILE"
 fi
 
 # Check SSH password authentication (handle both main config and overrides if they exist)
 if [ -n "$SSH_CONFIG_OVERRIDES" ] && [ -d "$(dirname "$SSH_CONFIG_OVERRIDES")" ]; then
-    SSH_PASSWORD=$(grep "^PasswordAuthentication" $SSH_CONFIG_OVERRIDES /etc/ssh/sshd_config 2>/dev/null | head -1 | awk '{print $2}')
+    SSH_PASSWORD=$(grep "^PasswordAuthentication" $SSH_CONFIG_OVERRIDES "$SSH_CONFIG_FILE" 2>/dev/null | head -1 | awk '{print $2}')
 else
-    SSH_PASSWORD=$(grep "^PasswordAuthentication" /etc/ssh/sshd_config 2>/dev/null | head -1 | awk '{print $2}')
+    SSH_PASSWORD=$(grep "^PasswordAuthentication" "$SSH_CONFIG_FILE" 2>/dev/null | head -1 | awk '{print $2}')
 fi
 if [ -z "$SSH_PASSWORD" ]; then
     SSH_PASSWORD="yes"
@@ -146,9 +204,9 @@ fi
 UNPRIVILEGED_PORT_START=$(sysctl -n net.ipv4.ip_unprivileged_port_start)
 SSH_PORT=""
 if [ -n "$SSH_CONFIG_OVERRIDES" ] && [ -d "$(dirname "$SSH_CONFIG_OVERRIDES")" ]; then
-    SSH_PORT=$(grep "^Port" $SSH_CONFIG_OVERRIDES /etc/ssh/sshd_config 2>/dev/null | head -1 | awk '{print $2}')
+    SSH_PORT=$(grep "^Port" $SSH_CONFIG_OVERRIDES "$SSH_CONFIG_FILE" 2>/dev/null | head -1 | awk '{print $2}')
 else
-    SSH_PORT=$(grep "^Port" /etc/ssh/sshd_config 2>/dev/null | head -1 | awk '{print $2}')
+    SSH_PORT=$(grep "^Port" "$SSH_CONFIG_FILE" 2>/dev/null | head -1 | awk '{print $2}')
 fi
 if [ -z "$SSH_PORT" ]; then
     SSH_PORT="22"
@@ -157,7 +215,7 @@ fi
 if [ "$SSH_PORT" = "22" ]; then
     check_security "SSH Port" "WARN" "Using default port 22 - consider changing to a non-standard port for security by obscurity"
 elif [ "$SSH_PORT" -ge "$UNPRIVILEGED_PORT_START" ]; then
-    check_security "SSH Port" "FAIL" "Using unprivileged port $SSH_PORT -  use a port below $UNPRIVILEGED_PORT_START for better security"
+    check_security "SSH Port" "FAIL" "Using unprivileged port $SSH_PORT - use a port below $UNPRIVILEGED_PORT_START for better security"
 else
     check_security "SSH Port" "PASS" "Using non-default port $SSH_PORT which helps prevent automated attacks"
 fi
@@ -248,13 +306,11 @@ case "$IPS_INSTALLED$IPS_ACTIVE" in
 esac
 
 # Check failed login attempts
-LOG_FILE="/var/log/auth.log"
-
-if [ -f "$LOG_FILE" ]; then
-    FAILED_LOGINS=$(grep -c "Failed password" "$LOG_FILE" 2>/dev/null || echo 0)
+if [ -f "$AUTH_LOG_FILE" ]; then
+    FAILED_LOGINS=$(grep -c "Failed password" "$AUTH_LOG_FILE" 2>/dev/null || echo 0)
 else
     FAILED_LOGINS=0
-    check_security "Auth Log" "WARN" "Log file $LOG_FILE not found or unreadable. Assuming 0 failed login attempts."
+    check_security "Auth Log" "WARN" "Log file $AUTH_LOG_FILE not found or unreadable. Assuming 0 failed login attempts."
 fi
 
 # Ensure FAILED_LOGINS is numeric and strip whitespace
@@ -262,9 +318,9 @@ FAILED_LOGINS=$(echo "$FAILED_LOGINS" | tr -d '[:space:]')
 # Remove leading zeros (if any)
 FAILED_LOGINS=$((10#$FAILED_LOGINS)) # Use arithmetic evaluation to ensure it's numeric and format correctly.
 
-if [ "$FAILED_LOGINS" -lt 10 ]; then
+if [ "$FAILED_LOGINS" -lt $LOGINS_WARN ]; then
     check_security "Failed Logins" "PASS" "Only $FAILED_LOGINS failed login attempts detected - this is within normal range"
-elif [ "$FAILED_LOGINS" -lt 50 ]; then
+elif [ "$FAILED_LOGINS" -lt $LOGINS_FAIL ]; then
     check_security "Failed Logins" "WARN" "$FAILED_LOGINS failed login attempts detected - might indicate breach attempts"
 else
     check_security "Failed Logins" "FAIL" "$FAILED_LOGINS failed login attempts detected - possible brute force attack in progress"
@@ -283,9 +339,9 @@ fi
 
 # Check running services
 SERVICES=$(systemctl list-units --type=service --state=running | grep -c "loaded active running")
-if [ "$SERVICES" -lt 20 ]; then
+if [ "$SERVICES" -lt $SERVICES_WARN ]; then
     check_security "Running Services" "PASS" "Running minimal services ($SERVICES) - good for security"
-elif [ "$SERVICES" -lt 40 ]; then
+elif [ "$SERVICES" -lt $SERVICES_FAIL ]; then
     check_security "Running Services" "WARN" "$SERVICES services running - consider reducing attack surface"
 else
     check_security "Running Services" "FAIL" "Too many services running ($SERVICES) - increases attack surface"
@@ -307,9 +363,9 @@ if [ -n "$LISTENING_PORTS" ]; then
     PORT_COUNT=$(echo "$PUBLIC_PORTS" | tr ',' '\n' | wc -w)
     INTERNET_PORTS=$(echo "$PUBLIC_PORTS" | tr ',' '\n' | wc -w)
 
-    if [ "$PORT_COUNT" -lt 10 ] && [ "$INTERNET_PORTS" -lt 3 ]; then
+    if [ "$PORT_COUNT" -lt $OPEN_PORTS_WARN ] && [ "$INTERNET_PORTS" -lt 3 ]; then
         check_security "Port Security" "PASS" "Good configuration (Total: $PORT_COUNT, Public: $INTERNET_PORTS accessible ports): $PUBLIC_PORTS"
-    elif [ "$PORT_COUNT" -lt 20 ] && [ "$INTERNET_PORTS" -lt 5 ]; then
+    elif [ "$PORT_COUNT" -lt $OPEN_PORTS_FAIL ] && [ "$INTERNET_PORTS" -lt 5 ]; then
         check_security "Port Security" "WARN" "Review recommended (Total: $PORT_COUNT, Public: $INTERNET_PORTS accessible ports): $PUBLIC_PORTS"
     else
         check_security "Port Security" "FAIL" "High exposure (Total: $PORT_COUNT, Public: $INTERNET_PORTS accessible ports): $PUBLIC_PORTS"
@@ -329,9 +385,9 @@ DISK_TOTAL=$(df -h / | awk 'NR==2 {print $2}')
 DISK_USED=$(df -h / | awk 'NR==2 {print $3}')
 DISK_AVAIL=$(df -h / | awk 'NR==2 {print $4}')
 DISK_USAGE=$(df -h / | awk 'NR==2 {print int($5)}')
-if [ "$DISK_USAGE" -lt 50 ]; then
+if [ "$DISK_USAGE" -lt $RESOURCE_WARN ]; then
     check_security "Disk Usage" "PASS" "Healthy disk space available (${DISK_USAGE}% used - Used: ${DISK_USED} of ${DISK_TOTAL}, Available: ${DISK_AVAIL})"
-elif [ "$DISK_USAGE" -lt 80 ]; then
+elif [ "$DISK_USAGE" -lt $RESOURCE_FAIL ]; then
     check_security "Disk Usage" "WARN" "Disk space usage is moderate (${DISK_USAGE}% used - Used: ${DISK_USED} of ${DISK_TOTAL}, Available: ${DISK_AVAIL})"
 else
     check_security "Disk Usage" "FAIL" "Critical disk space usage (${DISK_USAGE}% used - Used: ${DISK_USED} of ${DISK_TOTAL}, Available: ${DISK_AVAIL})"
@@ -342,9 +398,9 @@ MEM_TOTAL=$(free -h | awk '/^Mem:/ {print $2}')
 MEM_USED=$(free -h | awk '/^Mem:/ {print $3}')
 MEM_AVAIL=$(free -h | awk '/^Mem:/ {print $7}')
 MEM_USAGE=$(free | awk '/^Mem:/ {printf "%.0f", $3/$2 * 100}')
-if [ "$MEM_USAGE" -lt 50 ]; then
+if [ "$MEM_USAGE" -lt $RESOURCE_WARN ]; then
     check_security "Memory Usage" "PASS" "Healthy memory usage (${MEM_USAGE}% used - Used: ${MEM_USED} of ${MEM_TOTAL}, Available: ${MEM_AVAIL})"
-elif [ "$MEM_USAGE" -lt 80 ]; then
+elif [ "$MEM_USAGE" -lt $RESOURCE_FAIL ]; then
     check_security "Memory Usage" "WARN" "Moderate memory usage (${MEM_USAGE}% used - Used: ${MEM_USED} of ${MEM_TOTAL}, Available: ${MEM_AVAIL})"
 else
     check_security "Memory Usage" "FAIL" "Critical memory usage (${MEM_USAGE}% used - Used: ${MEM_USED} of ${MEM_TOTAL}, Available: ${MEM_AVAIL})"
@@ -355,24 +411,26 @@ CPU_CORES=$(nproc)
 CPU_USAGE=$(top -bn1 | grep "Cpu(s)" | awk '{print int($2)}')
 CPU_IDLE=$(top -bn1 | grep "Cpu(s)" | awk '{print int($8)}')
 CPU_LOAD=$(uptime | awk -F'load average:' '{ print $2 }' | awk -F',' '{ print $1 }' | tr -d ' ')
-if [ "$CPU_USAGE" -lt 50 ]; then
+if [ "$CPU_USAGE" -lt $RESOURCE_WARN ]; then
     check_security "CPU Usage" "PASS" "Healthy CPU usage (${CPU_USAGE}% used - Active: ${CPU_USAGE}%, Idle: ${CPU_IDLE}%, Load: ${CPU_LOAD}, Cores: ${CPU_CORES})"
-elif [ "$CPU_USAGE" -lt 80 ]; then
+elif [ "$CPU_USAGE" -lt $RESOURCE_FAIL ]; then
     check_security "CPU Usage" "WARN" "Moderate CPU usage (${CPU_USAGE}% used - Active: ${CPU_USAGE}%, Idle: ${CPU_IDLE}%, Load: ${CPU_LOAD}, Cores: ${CPU_CORES})"
 else
     check_security "CPU Usage" "FAIL" "Critical CPU usage (${CPU_USAGE}% used - Active: ${CPU_USAGE}%, Idle: ${CPU_IDLE}%, Load: ${CPU_LOAD}, Cores: ${CPU_CORES})"
 fi
 
 # Check sudo configuration
-if grep -q "^Defaults.*logfile" /etc/sudoers; then
+if grep -q "^Defaults.*logfile" "$SUDOERS_FILE"; then
     check_security "Sudo Logging" "PASS" "Sudo commands are being logged for audit purposes"
 else
     check_security "Sudo Logging" "FAIL" "Sudo commands are not being logged - reduces audit capability"
 fi
 
 # Check password policy
-if [ -f "/etc/security/pwquality.conf" ]; then
-    if grep -q "minlen.*12" /etc/security/pwquality.conf; then
+if [ -f "$PASSWORD_QUALITY_CONF" ]; then
+    # Extract the minlen value from pwquality.conf
+    MINLEN_VALUE=$(grep -E '^\s*minlen\s*=' "$PASSWORD_QUALITY_CONF" | awk -F= '{print $2}' | tr -d ' ')
+    if [ "$MINLEN_VALUE" -ge 12 ]; then
         check_security "Password Policy" "PASS" "Strong password policy is enforced"
     else
         check_security "Password Policy" "FAIL" "Weak password policy - passwords may be too simple"
@@ -401,16 +459,23 @@ echo "================================" >> "$REPORT_FILE"
 echo "System Information Summary:" >> "$REPORT_FILE"
 echo "Hostname: $(hostname)" >> "$REPORT_FILE"
 echo "Kernel: $(uname -r)" >> "$REPORT_FILE"
-echo "OS: $(grep PRETTY_NAME /etc/os-release | cut -d'"' -f2)" >> "$REPORT_FILE"
+echo "OS: $(grep PRETTY_NAME "$OS_RELEASE_FILE" | cut -d'"' -f2)" >> "$REPORT_FILE"
 echo "CPU Cores: $(nproc)" >> "$REPORT_FILE"
 echo "Total Memory: $(free -h | awk '/^Mem:/ {print $2}')" >> "$REPORT_FILE"
 echo "Total Disk Space: $(df -h / | awk 'NR==2 {print $2}')" >> "$REPORT_FILE"
 echo "================================" >> "$REPORT_FILE"
 
 echo -e "\nVPS audit complete. Full report saved to $REPORT_FILE"
-echo -e "Review $REPORT_FILE for detailed recommendations."
+echo -e "Review $REPORT_FILENAME for detailed recommendations."
 
 # Add summary to report
 echo "================================" >> "$REPORT_FILE"
 echo "End of VPS Audit Report" >> "$REPORT_FILE"
 echo "Please review all failed checks and implement the recommended fixes." >> "$REPORT_FILE"
+
+# If chown enabled, set ownership of report
+if [ "$ENABLE_CHOWN" = true ]; then
+	if ! chown "$REPORT_CHOWN_OWNER" "$REPORT_FILE"; then
+		echo -e "${RED}[ERROR] Failed to change ownership of ${REPORT_FILE}." >&2
+	fi
+fi

--- a/vps-audit.sh
+++ b/vps-audit.sh
@@ -1,5 +1,14 @@
 #!/usr/bin/env bash
 
+# Colors for output
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+YELLOW='\033[1;33m'
+GRAY='\033[0;90m'
+BLUE='\033[0;34m'
+BOLD='\033[1m'
+NC='\033[0m' # No Color
+
 # -----------------------------------------
 # Configuration
 # -----------------------------------------
@@ -28,6 +37,9 @@ LOGINS_FAIL=50    # FAIL if >= 50 failed logins
 OPEN_PORTS_WARN=10  # WARN if >= 10 open ports
 OPEN_PORTS_FAIL=20  # FAIL if >= 20 open ports
 
+# Password Policy
+PASSWORD_MINLEN=12  # PASS if pwquality minlen is >= this value
+
 # Report Output Configuration
 
 # Directory and File Naming
@@ -37,20 +49,22 @@ REPORT_FILENAME="vps-audit-report-${TIMESTAMP}.txt"
 REPORT_FILE="${DEFAULT_REPORT_DIR}/${REPORT_FILENAME}"
 
 # Ownership
-ENABLE_CHOWN=false  # Whether to apply chown to report directory
-REPORT_CHOWN_OWNER="$(id -un):$(id -gn)"  # user:group - if running via sudo will default to root:root
+ENABLE_CHOWN=false  # Whether to chown the report (and the report dir, if created)
+# Defaults to the user who invoked sudo, so reports are not left owned by root.
+CHOWN_USER="${SUDO_USER:-$(id -un)}"
+REPORT_CHOWN_OWNER="${CHOWN_USER}:$(id -gn "$CHOWN_USER" 2>/dev/null || id -gn)"
 
 # Ensure report directory exists
 if [ ! -d "$DEFAULT_REPORT_DIR" ]; then
     if mkdir -p "$DEFAULT_REPORT_DIR"; then
         # Apply ownership only when directory was created
         if [ "$ENABLE_CHOWN" = true ]; then
-            if ! chown -R "$REPORT_CHOWN_OWNER" "$DEFAULT_REPORT_DIR"; then
-                echo -e "${RED}[ERROR] Failed to change ownership of ${DEFAULT_REPORT_DIR}." >&2
+            if ! chown "$REPORT_CHOWN_OWNER" "$DEFAULT_REPORT_DIR"; then
+                echo -e "${RED}[ERROR] Failed to change ownership of ${DEFAULT_REPORT_DIR}.${NC}" >&2
             fi
         fi
     else
-        echo -e "${RED}[ERROR] Failed to create directory ${DEFAULT_REPORT_DIR}. Using current directory." >&2
+        echo -e "${RED}[ERROR] Failed to create directory ${DEFAULT_REPORT_DIR}. Using current directory.${NC}" >&2
         DEFAULT_REPORT_DIR="."
         REPORT_FILE="./${REPORT_FILENAME}"
         ENABLE_CHOWN=false
@@ -60,16 +74,6 @@ fi
 # -----------------------------------------
 # End Configuration
 # -----------------------------------------
-
-
-# Colors for output
-GREEN='\033[0;32m'
-RED='\033[0;31m'
-YELLOW='\033[1;33m'
-GRAY='\033[0;90m'
-BLUE='\033[0;34m'
-BOLD='\033[1m'
-NC='\033[0m' # No Color
 
 print_header() {
     local header="$1"
@@ -438,12 +442,16 @@ fi
 
 # Check password policy
 if [ -f "$PASSWORD_QUALITY_CONF" ]; then
-    # Extract the minlen value from pwquality.conf
-    MINLEN_VALUE=$(grep -E '^\s*minlen\s*=' "$PASSWORD_QUALITY_CONF" | awk -F= '{print $2}' | tr -d ' ')
-    if [ "$MINLEN_VALUE" -ge 12 ]; then
-        check_security "Password Policy" "PASS" "Strong password policy is enforced"
+    # Extract the minlen value from pwquality.conf (last uncommented definition wins)
+    MINLEN_VALUE=$(grep -E '^[[:space:]]*minlen[[:space:]]*=' "$PASSWORD_QUALITY_CONF" | tail -1 | cut -d= -f2 | tr -d '[:space:]')
+    if [ -z "$MINLEN_VALUE" ]; then
+        check_security "Password Policy" "FAIL" "No minlen set in $PASSWORD_QUALITY_CONF - system accepts weak passwords"
+    elif ! [[ "$MINLEN_VALUE" =~ ^[0-9]+$ ]]; then
+        check_security "Password Policy" "WARN" "Could not parse minlen value '$MINLEN_VALUE' in $PASSWORD_QUALITY_CONF"
+    elif [ "$MINLEN_VALUE" -ge "$PASSWORD_MINLEN" ]; then
+        check_security "Password Policy" "PASS" "Strong password policy is enforced (minlen=$MINLEN_VALUE)"
     else
-        check_security "Password Policy" "FAIL" "Weak password policy - passwords may be too simple"
+        check_security "Password Policy" "FAIL" "Weak password policy - minlen=$MINLEN_VALUE is below the recommended $PASSWORD_MINLEN"
     fi
 else
     check_security "Password Policy" "FAIL" "No password policy configured - system accepts weak passwords"
@@ -476,7 +484,7 @@ echo "Total Disk Space: $(df -h / | awk 'NR==2 {print $2}')" >> "$REPORT_FILE"
 echo "================================" >> "$REPORT_FILE"
 
 echo -e "\nVPS audit complete. Full report saved to $REPORT_FILE"
-echo -e "Review $REPORT_FILENAME for detailed recommendations."
+echo -e "Review $REPORT_FILE for detailed recommendations."
 
 # Add summary to report
 echo "================================" >> "$REPORT_FILE"
@@ -485,7 +493,7 @@ echo "Please review all failed checks and implement the recommended fixes." >> "
 
 # If chown enabled, set ownership of report
 if [ "$ENABLE_CHOWN" = true ]; then
-	if ! chown "$REPORT_CHOWN_OWNER" "$REPORT_FILE"; then
-		echo -e "${RED}[ERROR] Failed to change ownership of ${REPORT_FILE}." >&2
-	fi
+    if ! chown "$REPORT_CHOWN_OWNER" "$REPORT_FILE"; then
+        echo -e "${RED}[ERROR] Failed to change ownership of ${REPORT_FILE}." >&2
+    fi
 fi


### PR DESCRIPTION
Fixed:
- The Password Policy would only check if `MINLEN` was set to the default `12` and would fail any configurations with a higher `MINLEN` values. (Resolves #32) 

Added:
- Changed the log file creation behavior to separate the file and path variable.
- Added an option to `chown` the log path/reports (defaults to `false`). Does not `chown` the path if it already exists to prevent changing existing permissions.

Modified:
- Made configuration of thresholds and paths easier by using variables instead of static values
- Moved configuration variables to the top of the file
- Updated the README with configuration options