### PR TITLE
fix: execute journalctl as command instead of passing as string to grep

### DIFF
--- a/vps-audit.sh
+++ b/vps-audit.sh
@@ -257,7 +257,7 @@ if [ -f "$LOG_FILE" ]; then
 elif [ -f "/etc/debian_version" ]; then
     DEB_VERSION=$(cut -d'.' -f1 /etc/debian_version)
     if [ "$DEB_VERSION" -gt 10 ]; then
-        FAILED_LOGINS=$(grep -c "Failed password" "journalctl -u ssh --since \"24 hours ago\"" 2>/dev/null || echo 0)
+        FAILED_LOGINS=$(journalctl -u ssh --since "24 hours ago" 2>/dev/null | grep -c "Failed password" || echo 0)
     fi
 else
     FAILED_LOGINS=0


### PR DESCRIPTION
Debian 11+ stores auth logs in journald, not /var/log/auth.log.
The journalctl call was being passed as a literal string argument to grep,
so failed login count was always 0 on affected systems.
